### PR TITLE
#4 - 도메인 및 DTO 작성

### DIFF
--- a/src/main/java/com/hackathon/eot/dto/response/Response.java
+++ b/src/main/java/com/hackathon/eot/dto/response/Response.java
@@ -1,0 +1,28 @@
+package com.hackathon.eot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Response<T> implements Serializable {
+
+    private String resultCode;
+    private T result;
+
+    public static Response<Void> error(String errorCode) {
+        return new Response<>(errorCode, null);
+    }
+
+    public static Response<Void> success() {
+        return new Response<Void>("SUCCESS", null);
+    }
+
+    public static <T> Response<T> success(T result) {
+        return new Response<>("SUCCESS", result);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/constant/Gender.java
+++ b/src/main/java/com/hackathon/eot/model/constant/Gender.java
@@ -1,0 +1,5 @@
+package com.hackathon.eot.model.constant;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/hackathon/eot/model/constant/ImageRole.java
+++ b/src/main/java/com/hackathon/eot/model/constant/ImageRole.java
@@ -1,0 +1,5 @@
+package com.hackathon.eot.model.constant;
+
+public enum ImageRole {
+    CREATED, UPLOADED
+}

--- a/src/main/java/com/hackathon/eot/model/constant/UserRole.java
+++ b/src/main/java/com/hackathon/eot/model/constant/UserRole.java
@@ -1,0 +1,5 @@
+package com.hackathon.eot.model.constant;
+
+public enum UserRole {
+    ADMIN, USER
+}

--- a/src/main/java/com/hackathon/eot/model/dto/ArticleDto.java
+++ b/src/main/java/com/hackathon/eot/model/dto/ArticleDto.java
@@ -1,0 +1,40 @@
+package com.hackathon.eot.model.dto;
+
+import com.hackathon.eot.model.entity.ArticleEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ArticleDto {
+
+    private Long id;
+    private User user;
+    private Long plannerId;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ArticleDto of(User user, Long plannerId, String title, String content) {
+        return new ArticleDto(null, user, plannerId, title, content, null, null);
+    }
+
+    public static ArticleDto of(Long id, User user, Long plannerId, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new ArticleDto(id, user, plannerId, title, content, createdAt, modifiedAt);
+    }
+
+    public static ArticleDto fromEntity(ArticleEntity entity) {
+        return new ArticleDto(
+                entity.getId(),
+                User.fromEntity(entity.getUser()),
+                entity.getPlanner().getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/dto/BookmarkDto.java
+++ b/src/main/java/com/hackathon/eot/model/dto/BookmarkDto.java
@@ -1,0 +1,37 @@
+package com.hackathon.eot.model.dto;
+
+import com.hackathon.eot.model.entity.BookmarkEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookmarkDto {
+
+    private Long id;
+    private Long articleId;
+    private User user;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static BookmarkDto of(Long articleId, User user) {
+        return new BookmarkDto(null, articleId, user, null, null);
+    }
+
+    public static BookmarkDto of(Long id, Long articleId, User user, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new BookmarkDto(id, articleId, user, createdAt, modifiedAt);
+    }
+
+    public static BookmarkDto fromEntity(BookmarkEntity entity) {
+        return new BookmarkDto(
+                entity.getId(),
+                entity.getArticle().getId(),
+                User.fromEntity(entity.getUser()),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/dto/CommentDto.java
+++ b/src/main/java/com/hackathon/eot/model/dto/CommentDto.java
@@ -1,0 +1,39 @@
+package com.hackathon.eot.model.dto;
+
+import com.hackathon.eot.model.entity.CommentEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentDto {
+
+    private Long id;
+    private Long articleId;
+    private User user;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static CommentDto of(Long articleId, User user, String content) {
+        return new CommentDto(null, articleId, user, content, null, null);
+    }
+
+    public static CommentDto of(Long id, Long articleId, User user, String content, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new CommentDto(id, articleId, user, content, createdAt, modifiedAt);
+    }
+
+    public static CommentDto fromEntity(CommentEntity entity) {
+        return new CommentDto(
+                entity.getId(),
+                entity.getArticle().getId(),
+                User.fromEntity(entity.getUser()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/dto/ImageDto.java
+++ b/src/main/java/com/hackathon/eot/model/dto/ImageDto.java
@@ -1,0 +1,40 @@
+package com.hackathon.eot.model.dto;
+
+import com.hackathon.eot.model.constant.ImageRole;
+import com.hackathon.eot.model.entity.ImageEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageDto {
+
+    private Long id;
+    private Long articleId;
+    private String imageUrl;
+    private ImageRole role;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ImageDto of(Long articleId, String imageUrl, ImageRole role) {
+        return new ImageDto(null, articleId, imageUrl, role, null, null);
+    }
+
+    public static ImageDto of(Long id, Long articleId, String imageUrl, ImageRole role, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new ImageDto(id, articleId, imageUrl, role, createdAt, modifiedAt);
+    }
+
+    public static ImageDto fromEntity(ImageEntity entity) {
+        return new ImageDto(
+                entity.getId(),
+                entity.getArticle().getId(),
+                entity.getImageUrl(),
+                entity.getRole(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/dto/PlanDto.java
+++ b/src/main/java/com/hackathon/eot/model/dto/PlanDto.java
@@ -1,0 +1,45 @@
+package com.hackathon.eot.model.dto;
+
+import com.hackathon.eot.model.entity.PlanEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanDto {
+
+    private Long id;
+    private Long plannerId;
+    private String place;
+    private String content;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Long fee;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static PlanDto of(Long plannerId, String place, String content, LocalDateTime startTime, LocalDateTime endTime, Long fee) {
+        return new PlanDto(null, plannerId, place, content, startTime, endTime, fee, null, null);
+    }
+
+    public static PlanDto of(Long id, Long plannerId, String place, String content, LocalDateTime startTime, LocalDateTime endTime, Long fee, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new PlanDto(id, plannerId, place, content, startTime, endTime, fee, createdAt, modifiedAt);
+    }
+
+    public static PlanDto fromEntity(PlanEntity entity) {
+        return new PlanDto(
+                entity.getId(),
+                entity.getPlanner().getId(),
+                entity.getPlace(),
+                entity.getContent(),
+                entity.getStartTime(),
+                entity.getEndTime(),
+                entity.getFee(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/dto/PlannerDto.java
+++ b/src/main/java/com/hackathon/eot/model/dto/PlannerDto.java
@@ -1,0 +1,37 @@
+package com.hackathon.eot.model.dto;
+
+import com.hackathon.eot.model.entity.PlannerEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlannerDto {
+
+    private Long id;
+    private User user;
+    private String title;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static PlannerDto of(User user, String title) {
+        return new PlannerDto(null, user, title, null, null);
+    }
+
+    public static PlannerDto of(Long id, User user, String title, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new PlannerDto(id, user, title, createdAt, modifiedAt);
+    }
+
+    public static PlannerDto fromEntity(PlannerEntity entity) {
+        return new PlannerDto(
+                entity.getId(),
+                User.fromEntity(entity.getUser()),
+                entity.getTitle(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/dto/User.java
+++ b/src/main/java/com/hackathon/eot/model/dto/User.java
@@ -1,0 +1,82 @@
+package com.hackathon.eot.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.hackathon.eot.model.constant.Gender;
+import com.hackathon.eot.model.constant.UserRole;
+import com.hackathon.eot.model.entity.UserAccount;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class User implements UserDetails {
+
+    private Long id;
+    private String username;
+    private String password;
+    private UserRole userRole;
+    private String name;
+    private String nickname;
+    private String birthday;
+    private Gender gender;
+    private String address;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static User fromEntity(UserAccount entity) {
+        return new User(
+                entity.getId(),
+                entity.getUserAccountId(),
+                entity.getPassword(),
+                entity.getRole(),
+                entity.getName(),
+                entity.getNickname(),
+                entity.getBirthday(),
+                entity.getGender(),
+                entity.getAddress(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+
+    @Override
+    @JsonIgnore
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(this.getUserRole().toString()));
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/ArticleEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/ArticleEntity.java
@@ -1,0 +1,42 @@
+package com.hackathon.eot.model.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "article")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ArticleEntity extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @ManyToOne
+    @JoinColumn(name = "planner_id")
+    private PlannerEntity planner;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    private ArticleEntity(UserAccount userAccount, PlannerEntity plannerEntity, String title, String content) {
+        this.user = userAccount;
+        this.planner = plannerEntity;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static ArticleEntity of(UserAccount userAccount, PlannerEntity plannerEntity, String title, String content) {
+        return new ArticleEntity(userAccount, plannerEntity, title, content);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/AuditingFields.java
+++ b/src/main/java/com/hackathon/eot/model/entity/AuditingFields.java
@@ -1,0 +1,33 @@
+package com.hackathon.eot.model.entity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@JsonInclude(Include.NON_NULL)
+@Getter
+@ToString
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+}

--- a/src/main/java/com/hackathon/eot/model/entity/BookmarkEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/BookmarkEntity.java
@@ -1,0 +1,34 @@
+package com.hackathon.eot.model.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "bookmark")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BookmarkEntity extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "article_id")
+    private ArticleEntity article;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    private BookmarkEntity(ArticleEntity articleEntity, UserAccount userAccount) {
+        this.article = articleEntity;
+        this.user = userAccount;
+    }
+
+    public static BookmarkEntity of(ArticleEntity articleEntity, UserAccount userAccount) {
+        return new BookmarkEntity(articleEntity, userAccount);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/CommentEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/CommentEntity.java
@@ -1,0 +1,38 @@
+package com.hackathon.eot.model.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "article_comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class CommentEntity extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "article_id")
+    private ArticleEntity article;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @Column(name = "content")
+    private String content;
+
+    private CommentEntity(ArticleEntity articleEntity, UserAccount userAccount, String content) {
+        this.article = articleEntity;
+        this.user = userAccount;
+        this.content = content;
+    }
+
+    public static CommentEntity of(ArticleEntity articleEntity, UserAccount userAccount, String content) {
+        return new CommentEntity(articleEntity, userAccount, content);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/ImageEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/ImageEntity.java
@@ -1,0 +1,39 @@
+package com.hackathon.eot.model.entity;
+
+import com.hackathon.eot.model.constant.ImageRole;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ImageEntity extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "article_id")
+    private ArticleEntity article;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private ImageRole role;
+
+    private ImageEntity(ArticleEntity articleEntity, String imageUrl, ImageRole imageRole) {
+        this.article = articleEntity;
+        this.imageUrl = imageUrl;
+        this.role = imageRole;
+    }
+
+    public static ImageEntity of(ArticleEntity articleEntity, String imageUrl, ImageRole imageRole) {
+        return new ImageEntity(articleEntity, imageUrl, imageRole);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/PlanEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/PlanEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "plan")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class PlanEntity {
+public class PlanEntity extends AuditingFields {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/hackathon/eot/model/entity/PlanEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/PlanEntity.java
@@ -1,0 +1,54 @@
+package com.hackathon.eot.model.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Table(name = "plan")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PlanEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "planner_id")
+    private PlannerEntity planner;
+
+    @Column(name = "place")
+    private String place;
+
+    @Column(name = "conetent")
+    private String content;
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "fee")
+    private Long fee;
+
+    private PlanEntity(PlannerEntity plannerEntity, String place, String content, LocalDateTime startTime, LocalDateTime endTime, Long fee) {
+        this.planner = plannerEntity;
+        this.place = place;
+        this.content = content;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.fee = fee;
+    }
+
+    public static PlanEntity of(PlannerEntity plannerEntity, String place, String content, LocalDateTime startTime, LocalDateTime endTime, Long fee) {
+        return new PlanEntity(plannerEntity, place, content, startTime, endTime, fee);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/PlannerEntity.java
+++ b/src/main/java/com/hackathon/eot/model/entity/PlannerEntity.java
@@ -1,0 +1,33 @@
+package com.hackathon.eot.model.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "planner")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PlannerEntity extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @Column(name = "title")
+    private String title;
+
+    private PlannerEntity(UserAccount userAccount, String title) {
+        this.user = userAccount;
+        this.title = title;
+    }
+
+    public static PlannerEntity of(UserAccount userAccount, String title) {
+        return new PlannerEntity(userAccount, title);
+    }
+}

--- a/src/main/java/com/hackathon/eot/model/entity/UserAccount.java
+++ b/src/main/java/com/hackathon/eot/model/entity/UserAccount.java
@@ -1,0 +1,57 @@
+package com.hackathon.eot.model.entity;
+
+import com.hackathon.eot.model.constant.Gender;
+import com.hackathon.eot.model.constant.UserRole;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserAccount extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_account_id", nullable = false)
+    private String userAccountId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private UserRole role = UserRole.USER;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+    @Column(name = "birthday")
+    private String birthday;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
+    @Column(name = "address")
+    private String address;
+
+    private UserAccount(String userAccountId, String password, String name, String nickname, String birthday, Gender gender, String address) {
+        this.userAccountId = userAccountId;
+        this.password = password;
+        this.name = name;
+        this.nickname = nickname;
+        this.birthday = birthday;
+        this.gender = gender;
+        this.address = address;
+    }
+
+    public static UserAccount of(String userAccountId, String password, String name, String nickname, String birthday, Gender gender, String address) {
+        return new UserAccount(userAccountId, password, name, nickname, birthday, gender, address);
+    }
+}


### PR DESCRIPTION
E.O.T 프로젝트에서 사용하기 위한 엔티티와 같은 도메인을 작성하였다.
추가적으로 엔티티를 그대로 사용하여 엔티티의 정보가 수정 또는 삭제된다면 DB에 저장된 정보가 변경될 수 있기 때문에
이를 위한 DTO를 작성하였으며, 클라이언트에게 일관된 형식의 응답을 전달하기 위한 기초적인 Response DTO를 구현하였다.

This closes #4 